### PR TITLE
Support env vars and json escape strategy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ vendor:
 	composer install
 
 twigc.phar: vendor
-	php bin/compile
+	php -d phar.readonly=0 bin/compile
 
 build: twigc.phar
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Options:
   -V, --version        Display version information
       --credits        Display dependency credits (including Twig version)
   -d, --dir=DIR        Add search directory to loader (multiple values allowed)
+      --env            Treat environment variables as input data
   -e, --escape=ESCAPE  Set autoescape environment option
   -j, --json=JSON      Pass variables as JSON (dictionary string or file path)
   -p, --pair=PAIR      Pass variable as key=value pair (multiple values allowed)

--- a/src/Twigc/DefaultCommand.php
+++ b/src/Twigc/DefaultCommand.php
@@ -64,6 +64,12 @@ class DefaultCommand extends Command {
 				'Add search directory to loader'
 			)
 			->addOption(
+				'env',
+				null,
+				InputOption::VALUE_NONE,
+				'Treat environment variables as input data'
+			)
+			->addOption(
 				'escape',
 				'e',
 				InputOption::VALUE_REQUIRED,
@@ -347,6 +353,10 @@ class DefaultCommand extends Command {
 
 				$inputData[$kv[0]] = $kv[1];
 			}
+		}
+
+		if ( $input->getOption('env') ) {
+			$inputData = array_merge($_ENV, $inputData);
 		}
 
 		// Validate key names now

--- a/src/Twigc/DefaultCommand.php
+++ b/src/Twigc/DefaultCommand.php
@@ -260,6 +260,9 @@ class DefaultCommand extends Command {
 				case 'js':
 					$escape = 'js';
 					break;
+				case 'json':
+					$escape = 'json';
+					break;
 				default:
 					$escape = false;
 					break;
@@ -408,6 +411,16 @@ class DefaultCommand extends Command {
 				'strict_variables' => $strict,
 				'autoescape'       => $escape,
 			]);
+
+			$twig->getExtension('core')->setEscaper(
+				'json',
+				function($twigEnv, $string, $charset) {
+					return json_encode(
+						$string,
+						\JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE
+					);
+				}
+			);
 
 			$output->writeln(
 				rtrim($twig->render(basename($template), $inputData), "\r\n")


### PR DESCRIPTION
This enables me to use twigc to generate configuration files. Almost all the configuration languages I use are a superset of JSON, so a simple json escaper goes a long way.